### PR TITLE
fix: update overrideTxRedeemers to compute script data hash from new redeemers

### DIFF
--- a/src/TxBuilder/TxBuilder.ts
+++ b/src/TxBuilder/TxBuilder.ts
@@ -370,31 +370,32 @@ export class TxBuilder
      * 2) `tx.witnesses.redeemers`
      * 3) `tx.witnesses.vkeyWitnesses` (empty)
      */
-    overrideTxRedeemers( 
-        tx: Tx, 
+    overrideTxRedeemers(
+        tx: Tx,
         newRedeemers: TxRedeemer[],
         opts: CostModelsToLanguageViewCborOpts = { mustHaveV3: true }
     ): Tx
     {
-        // datums passed by hash
-        const datums = tx.witnesses.datums ?? [];
+        // the script data hash commits to the redeemers in the witness set,
+        // so it must be computed from the witness set carrying `newRedeemers`
+        const witnesses = new TxWitnessSet({
+            ...tx.witnesses,
+            vkeyWitnesses: [],
+            redeemers: newRedeemers
+        });
         return new Tx({
             ...tx,
             body: new TxBody({
                 ...tx.body,
                 scriptDataHash: getScriptDataHash(
-                    tx.witnesses,
+                    witnesses,
                     costModelsToLanguageViewCbor(
                         this.protocolParamters.costModels,
                         opts
                     )
                 )
             }),
-            witnesses: new TxWitnessSet({
-                ...tx.witnesses,
-                vkeyWitnesses: [],
-                redeemers: newRedeemers
-            })
+            witnesses
         });
     }
 


### PR DESCRIPTION
## Summary

`overrideTxRedeemers(tx, newRedeemers)` replaces the redeemers in the witness set but
computes the new `scriptDataHash` from the **old** witness set (`tx.witnesses`) instead of
the new one containing `newRedeemers`. The returned transaction, therefore, carries a
`scriptDataHash` that does not commit to its own redeemers. 

This PR fixes the function so that the new redeemers are first used to calculate the witness set, and then to build the hash using the witness set containing the `newRedeemers`. 

Have a look at it, and if you have any questions, feel free to get in touch. I also have a test suite with four specific tests for this function locally; if you like, I can add that to the branch as well!

Thanks in advance, and best regards, Max