### PR TITLE
fix: keepRelevant coin selection selects the entire wallet

### DIFF
--- a/src/TxBuilder/__tests__/keepRelevant.test.ts
+++ b/src/TxBuilder/__tests__/keepRelevant.test.ts
@@ -1,0 +1,158 @@
+import { Address, TxOutRef, TxOut, UTxO, Value } from "@harmoniclabs/cardano-ledger-ts";
+import { keepRelevant } from "../keepRelevant";
+import { ITxBuildInput } from "../../txBuild";
+
+const POLICY = "def68337867cb4f1f95b6b811fedbfcdd7780d10a95cc072077088ea";
+const ASSET_NAME = "546f6b656e4d";
+const ASSET_UNIT = POLICY + ASSET_NAME;
+
+function mkInput( txHashByte: string, index: number, value: Value ): ITxBuildInput
+{
+    return {
+        utxo: new UTxO({
+            utxoRef: new TxOutRef({ id: txHashByte.repeat( 32 ), index }),
+            resolved: new TxOut({
+                address: Address.fake,
+                value
+            })
+        })
+    };
+}
+
+const adaInput = ( txHashByte: string, lovelaces: number | bigint, index: number = 0 ) =>
+    mkInput( txHashByte, index, Value.lovelaces( lovelaces ) );
+
+const assetInput = ( txHashByte: string, lovelaces: number, assetQty: number ) =>
+    mkInput( txHashByte, 0, Value.fromUnits([
+        { unit: "lovelace", quantity: lovelaces },
+        { unit: ASSET_UNIT, quantity: assetQty }
+    ]));
+
+const refStr = ( input: ITxBuildInput ) =>
+    input.utxo.utxoRef.id.toString() + "#" + input.utxo.utxoRef.index.toString();
+
+describe("keepRelevant", () => {
+
+    describe("lovelace-only requests", () => {
+
+        // 10 x 100 ADA
+        const wallet = Array.from({ length: 10 }, (_, i) =>
+            adaInput( (i + 1).toString( 16 ).padStart( 2, "0" ), 100_000_000 )
+        );
+
+        test("does NOT select the whole wallet for a small request (Value input)", () => {
+            const selected = keepRelevant( Value.lovelaces( 2_000_000 ), wallet );
+            // 2 ADA requested + 5 ADA default minimum → a single 100 ADA input suffices
+            expect( selected.length ).toBe( 1 );
+        });
+
+        test("same result for the ValueUnits array shape", () => {
+            const selected = keepRelevant( Value.lovelaces( 2_000_000 ).toUnits(), wallet );
+            expect( selected.length ).toBe( 1 );
+        });
+
+        test("same result for the legacy record shape", () => {
+            const selected = keepRelevant( { lovelace: 2_000_000n } as any, wallet );
+            expect( selected.length ).toBe( 1 );
+        });
+
+        test("same result for a Value from a foreign realm (instanceof fails, toUnits present)", () => {
+            // simulates a duplicated cardano-ledger-ts in node_modules
+            const foreignValue = {
+                toUnits: () => Value.lovelaces( 2_000_000 ).toUnits()
+            };
+            const selected = keepRelevant( foreignValue as any, wallet );
+            expect( selected.length ).toBe( 1 );
+        });
+
+        test("honors the requested lovelace amount, not just the minimum", () => {
+            // 250 ADA requested + 5 ADA minimum → needs 3 of the 100 ADA inputs
+            const selected = keepRelevant( Value.lovelaces( 250_000_000 ), wallet );
+            const total = selected.reduce(
+                ( sum, i ) => sum + new UTxO( i.utxo ).resolved.value.lovelaces,
+                BigInt( 0 )
+            );
+            expect( selected.length ).toBe( 3 );
+            expect( total >= 255_000_000n ).toBe( true );
+        });
+
+        test("respects a custom minimumLovelaceRequired", () => {
+            const selected = keepRelevant( Value.lovelaces( 2_000_000 ), wallet, 150_000_000 );
+            // 2 + 150 ADA → needs 2 inputs
+            expect( selected.length ).toBe( 2 );
+        });
+
+        test("prefers smaller UTxOs first for the lovelace top-up", () => {
+            const mixed = [
+                adaInput( "aa", 100_000_000 ),
+                adaInput( "bb", 3_000_000 ),
+                adaInput( "cc", 5_000_000 ),
+            ];
+            // 1 ADA + 5 ADA min = 6 ADA → 3 + 5 = 8 ADA from the two small inputs
+            const selected = keepRelevant( Value.lovelaces( 1_000_000 ), mixed );
+            const ids = selected.map( refStr );
+            expect( selected.length ).toBe( 2 );
+            expect( ids ).toContain( refStr( mixed[1] ) );
+            expect( ids ).toContain( refStr( mixed[2] ) );
+        });
+
+        test("returns everything when the wallet cannot cover the request", () => {
+            const small = [ adaInput( "aa", 1_000_000 ), adaInput( "bb", 1_000_000 ) ];
+            const selected = keepRelevant( Value.lovelaces( 100_000_000 ), small );
+            expect( selected.length ).toBe( 2 );
+        });
+    });
+
+    describe("multi-asset requests", () => {
+
+        const wallet = [
+            adaInput( "aa", 100_000_000 ),
+            assetInput( "bb", 2_000_000, 5 ),
+            adaInput( "cc", 100_000_000 ),
+        ];
+
+        test("selects the asset-bearing UTxO plus a lovelace top-up only as needed", () => {
+            const requested = Value.fromUnits([
+                { unit: "lovelace", quantity: 2_000_000 },
+                { unit: ASSET_UNIT, quantity: 1 }
+            ]);
+            const selected = keepRelevant( requested, wallet );
+            const ids = selected.map( refStr );
+
+            // asset UTxO always kept; its 2 ADA < 7 ADA required → exactly one top-up input
+            expect( ids ).toContain( refStr( wallet[1] ) );
+            expect( selected.length ).toBe( 2 );
+        });
+
+        test("does not treat plain-ADA UTxOs as multi-asset matches", () => {
+            const requested = Value.fromUnits([
+                { unit: ASSET_UNIT, quantity: 1 }
+            ]);
+            const selected = keepRelevant( requested, wallet, 1_000_000 );
+            const ids = selected.map( refStr );
+
+            expect( ids ).toContain( refStr( wallet[1] ) );
+            // asset UTxO already carries 2 ADA ≥ 1 ADA minimum → no extra inputs
+            expect( selected.length ).toBe( 1 );
+        });
+    });
+
+    test("deduplicates by full out-ref, not only by tx hash", () => {
+        // two outputs of the SAME transaction: one holds the asset, one plain ADA
+        const sameTxAsset = assetInput( "dd", 2_000_000, 5 );
+        const sameTxAda = adaInput( "dd", 100_000_000, 1 );
+        const wallet = [ sameTxAsset, sameTxAda ];
+
+        const requested = Value.fromUnits([
+            { unit: "lovelace", quantity: 50_000_000 },
+            { unit: ASSET_UNIT, quantity: 1 }
+        ]);
+        const selected = keepRelevant( requested, wallet );
+        const ids = selected.map( refStr );
+
+        // the sibling output must remain available for the lovelace top-up
+        expect( ids ).toContain( refStr( sameTxAsset ) );
+        expect( ids ).toContain( refStr( sameTxAda ) );
+        expect( selected.length ).toBe( 2 );
+    });
+});

--- a/src/TxBuilder/keepRelevant.ts
+++ b/src/TxBuilder/keepRelevant.ts
@@ -2,71 +2,101 @@ import { ValueUnits, Value, UTxO } from "@harmoniclabs/cardano-ledger-ts";
 import { ITxBuildInput, cloneITxBuildInput } from "../txBuild";
 import { CanBeUInteger, forceBigUInt } from "../utils/ints";
 
+type UnitQuantities = { [unit: string]: bigint };
 
 export function keepRelevant(
     requestedOutputSet: ValueUnits | Value,
     initialUTxOSet: ITxBuildInput[],
     minimumLovelaceRequired: CanBeUInteger = 5_000_000,
-): ITxBuildInput[]
-{
-    if( requestedOutputSet instanceof Value )
-    {
-        requestedOutputSet = requestedOutputSet.toUnits();
-    }
+): ITxBuildInput[] {
+    const requested = normalizeRequestedOutputSet(requestedOutputSet);
 
-    const reqOutputKeys = Object.keys( requestedOutputSet );
+    const requestedLovelace =
+        (requested["lovelace"] ?? BigInt(0)) + forceBigUInt(minimumLovelaceRequired);
 
-    const requestedLovelace = reqOutputKeys.includes("lovelace")
-        ? forceBigUInt( BigInt( ( requestedOutputSet as any )["lovelace"] ) ) + forceBigUInt( minimumLovelaceRequired )
-        : forceBigUInt( minimumLovelaceRequired );
+    const requestedAssetUnits = Object.keys(requested)
+        .filter((unit) => unit !== "lovelace");
 
     const multiAssetIns = initialUTxOSet.filter((input) =>
-        new UTxO( input.utxo ).resolved.value.toUnits()
-            // .filter(( asset ) => asset.unit !== "lovelace")
-            .some(( asset ) => reqOutputKeys.includes( asset.unit ))
+        new UTxO(input.utxo).resolved.value.toUnits()
+            .filter((asset) => asset.unit !== "lovelace")
+            .some((asset) => requestedAssetUnits.includes(asset.unit))
     );
 
-    const totLovelaces = getTotLovelaces( multiAssetIns );
+    const totLovelaces = getTotLovelaces(multiAssetIns);
 
     const lovelaceIns = totLovelaces < requestedLovelace ?
         remainingLovelace(
             requestedLovelace - totLovelaces,
             // filter out initial utxos already included trough multi asset selection
-            initialUTxOSet.filter(( initialUtxo ) => {
+            initialUTxOSet.filter((initialUtxo) => {
 
-                const idStr = initialUtxo.utxo.utxoRef.id.toString();
+                const refStr = utxoRefStr(initialUtxo);
 
-                return !multiAssetIns.some(( selectedUtxo ) =>
-                    selectedUtxo.utxo.utxoRef.id.toString() === idStr
+                return !multiAssetIns.some((selectedUtxo) =>
+                    utxoRefStr(selectedUtxo) === refStr
                 );
             })
         )
         : [];
 
-        
-    return lovelaceIns.concat( multiAssetIns )
-        .map( cloneITxBuildInput );
+    return lovelaceIns.concat(multiAssetIns)
+        .map(cloneITxBuildInput);
 }
 
-function getTotLovelaces(multiAsset: ITxBuildInput[])
-{
+/**
+ * `keepRelevant` historically accepted (and documented) two different shapes:
+ * the `ValueUnits` array returned by `Value.toUnits()` and a Mesh-style
+ * `{ [unit]: quantity }` record. Normalize both to a record with `bigint`
+ * quantities so the rest of the algorithm only deals with one shape.
+ */
+function normalizeRequestedOutputSet(requested: ValueUnits | Value): UnitQuantities {
+    if (
+        requested instanceof Value ||
+        // tolerate `Value` instances from a duplicated `cardano-ledger-ts`
+        // in node_modules, where `instanceof` fails across the two copies
+        (!Array.isArray(requested) && typeof (requested as any)?.toUnits === "function")
+    ) {
+        requested = (requested as Value).toUnits();
+    }
+
+    const result: UnitQuantities = {};
+
+    if (Array.isArray(requested)) {
+        for (const { unit, quantity } of requested) {
+            result[unit] = (result[unit] ?? BigInt(0)) + BigInt(quantity);
+        }
+        return result;
+    }
+
+    for (const unit of Object.keys(requested as object)) {
+        result[unit] = BigInt((requested as any)[unit]);
+    }
+    return result;
+}
+
+function utxoRefStr(input: ITxBuildInput): string {
+    const ref = input.utxo.utxoRef;
+    return ref.id.toString() + "#" + ref.index.toString();
+}
+
+function getTotLovelaces(multiAsset: ITxBuildInput[]): bigint {
     return multiAsset.reduce(
-        (sum, input) => sum + new UTxO(input.utxo).resolved.value.lovelaces, 
+        (sum, input) => sum + new UTxO(input.utxo).resolved.value.lovelaces,
         BigInt(0)
     );
 };
 
-function remainingLovelace(quantity: bigint, initialUTxOSet: ITxBuildInput[]): ITxBuildInput[]
-{
-    const sortedUTxOs = initialUTxOSet.sort(
-        (a, b) => parseInt(
-            BigInt(
-                new UTxO(a.utxo).resolved.value.lovelaces - new UTxO(b.utxo).resolved.value.lovelaces
-            ).toString()
-        )
+function remainingLovelace(quantity: bigint, initialUTxOSet: ITxBuildInput[]): ITxBuildInput[] {
+    const sortedUTxOs = initialUTxOSet.slice().sort(
+        (a, b) => {
+            const aLovelaces = new UTxO(a.utxo).resolved.value.lovelaces;
+            const bLovelaces = new UTxO(b.utxo).resolved.value.lovelaces;
+            return aLovelaces < bLovelaces ? -1 : aLovelaces > bLovelaces ? 1 : 0;
+        }
     );
 
-    const requestedOutputSet = {
+    const requestedOutputSet: UnitQuantities = {
         lovelace: quantity
     };
 
@@ -78,49 +108,43 @@ function remainingLovelace(quantity: bigint, initialUTxOSet: ITxBuildInput[]): I
 }
 
 function enoughValueHasBeenSelected(
-    selection: ITxBuildInput[], assets: { [ unit: string ]: bigint },
+    selection: ITxBuildInput[], assets: UnitQuantities,
 ): boolean {
-    return Object.keys( assets )
+    return Object.keys(assets)
         .every((unit) => {
 
             return selection
-                .filter(( input ) => {
-                    return new UTxO(input.utxo).resolved.value.toUnits()
-                        .some((a) => a.unit === unit );
-                })
                 .reduce(
                     (selectedQuantity, input) => {
                         const utxoQuantity = new UTxO(input.utxo).resolved.value.toUnits()
                             .reduce(
-                                (quantity, a) => quantity + unit === a.unit ? BigInt( a.quantity ) : BigInt(0),
+                                (quantity, a) => quantity + (unit === a.unit ? BigInt(a.quantity) : BigInt(0)),
                                 BigInt(0),
                             );
 
                         return selectedQuantity + utxoQuantity;
                     },
                     BigInt(0)
-                ) < BigInt( assets[unit] ) === false;
+                ) >= assets[unit];
         });
 }
 
 function selectValue(
     inputUTxO: ITxBuildInput[],
-    outputSet: { [ unit: string ]: bigint },
+    outputSet: UnitQuantities,
     selection: ITxBuildInput[] = []
 ): ITxBuildInput[] {
     if (
-        inputUTxO.length === 0 || 
+        inputUTxO.length === 0 ||
         enoughValueHasBeenSelected(selection, outputSet)
-    )
-    {
+    ) {
         return selection;
     }
 
-    if( canValueBeSelected( inputUTxO[0], outputSet ) )
-    {
+    if (canValueBeSelected(inputUTxO[0], outputSet)) {
         return selectValue(
             inputUTxO.slice(1), outputSet,
-            selection.concat( inputUTxO[0] )
+            selection.concat(inputUTxO[0])
         );
     }
 
@@ -132,11 +156,10 @@ function selectValue(
 
 function canValueBeSelected(
     input: ITxBuildInput,
-    assets: { [ unit: string ]: bigint }
-): boolean
-{
-    return Object.keys( assets ).some(( unit ) => {
+    assets: UnitQuantities
+): boolean {
+    return Object.keys(assets).some((unit) => {
         return new UTxO(input.utxo).resolved.value.toUnits()
-            .some(( asset ) => asset.unit === unit );
+            .some((asset) => asset.unit === unit);
     });
 }


### PR DESCRIPTION
**Branch:** `fix/keep-relevant-coin-selection` (based on `upstream/main`)
**File:** `src/TxBuilder/keepRelevant.ts` (+ new `src/TxBuilder/__tests__/keepRelevant.test.ts`)

## Summary

`keepRelevant` currently returns **every** UTxO of the initial set for **every documented input shape** (`Value`, `ValueUnits` array, and the Mesh-style `{ [unit]: quantity }` record). Coin selection is effectively disabled: transaction size and fees scale with wallet size, and large wallets will hit `maxTxSize`.

Repro (10 × 100 ADA wallet, 2 ADA requested → expected 1 input):

```js
const wallet = Array.from({ length: 10 }, (_, i) => mkAdaInput(i, 100_000_000));
keepRelevant(Value.lovelaces(2_000_000n), wallet).length;           // 10 ❌
keepRelevant(Value.lovelaces(2_000_000n).toUnits(), wallet).length; // 10 ❌
keepRelevant({ lovelace: 2_000_000n }, wallet).length;              // 10 ❌
```

## Root causes (4 independent bugs)

1. **Array treated as record.** `Value.toUnits()` returns an array (`ValueUnits = ValueUnitEntry[]`), but the code does `Object.keys(requestedOutputSet)` and `requestedOutputSet["lovelace"]`. Keys become `"0", "1", …`, so the requested lovelace amount is silently dropped (only `minimumLovelaceRequired` survives) and multi-asset matching never matches. There is no type-correct way to call the function and get correct behavior.

2. **Lovelace-exclusion filter commented out.** Mesh filters `asset.unit !== "lovelace"` before multi-asset matching; here that line is commented. With a record input containing `lovelace`, every UTxO qualifies as a "multi-asset input" → whole wallet returned directly.

3. **Operator precedence + discarded accumulator** in `enoughValueHasBeenSelected`:
   ```ts
   (quantity, a) => quantity + unit === a.unit ? BigInt(a.quantity) : BigInt(0)
   ```
   parses as `((quantity + unit) === a.unit) ? …` a BigInt-to-string concatenation (`"0lovelace"`) compared against a unit, which is essentially always false, and the reduce returns the bare ternary, discarding the accumulator. The selected quantity is permanently `0n`, so "enough" is never reached, and `selectValue` takes every candidate.

4. **Dedup by tx hash only.** The "already selected via multi-asset" filter compares `utxoRef.id` alone, so a sibling output of the same transaction is wrongly excluded from the lovelace top-up candidates.

## Fix

- Normalize the input once (`Value` → `toUnits()`; array → record; legacy record tolerated) so the algorithm deals with a single `{ [unit]: bigint }` shape. `Value` detection duck-types on `toUnits` in addition to `instanceof`, so `Value` instances from a duplicated `cardano-ledger-ts` copy in `node_modules` (where `instanceof` fails across copies) are still handled correctly.
- Restore the `unit !== "lovelace"` filter for multi-asset matching (matching Mesh).
- Fix the accumulation: `quantity + (unit === a.unit ? BigInt(a.quantity) : BigInt(0))`, and compare with `>=` instead of `< … === false`.
- Deduplicate by full out-ref (`id#index`).
- Replace the `parseInt(BigInt(a − b).toString())` sort comparator with a precision-safe bigint comparison (and avoid mutating the caller's array via `.slice()`).

Selection semantics are unchanged, keep all UTxOs that hold the requested assets, then top up lovelace from the smallest UTxOs until the requested amount plus the minimum is covered.

## Tests

11 new tests in `src/TxBuilder/__tests__/keepRelevant.test.ts`:
- minimal selection for small requests across all three input shapes (1 of 10 inputs, not 10 of 10), plus the foreign-realm `Value` case
- requested lovelace amount honored (250 ADA → 3 × 100 ADA inputs)
- custom `minimumLovelaceRequired` honored
- smallest-first top-up ordering
- whole wallet returned only when it genuinely cannot cover the request
- multi-asset: asset UTxO kept, plain-ADA UTxOs not treated as asset matches, top-up only as needed
- dedup by full out-ref (two outputs of the same tx)